### PR TITLE
Limit simultaneous downloads to 15

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,14 +12,14 @@ function sleep(ms) {
 function download(url, filename) {
 	return new Promise(async (resolve, reject) => {
 		try {
-			const downloadId = await chrome.downloads.download({
+			const id = await chrome.downloads.download({
 				url, filename
 			});
 			chrome.downloads.onChanged.addListener(function onDownloadComplete(delta) {
-				if (delta.id == downloadId) {
+				if (delta.id == id) {
 					if (delta.state && delta.state.current === 'complete') {
 						chrome.downloads.onChanged.removeListener(onDownloadComplete);
-						resolve();
+						resolve(id);
 					} else if (delta.error) {
 						chrome.downloads.onChanged.removeListener(onDownloadComplete);
 						reject(new Error(delta.error.current));

--- a/background.js
+++ b/background.js
@@ -5,6 +5,10 @@ chrome.action.onClicked.addListener((tab) => {
 	});
 });
 
+function sleep(ms) {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 function download(url, filename) {
 	return new Promise(async (resolve, reject) => {
 		try {
@@ -47,6 +51,7 @@ chrome.runtime.onMessage.addListener((arg, sender, sendResponse) => {
 				while (queue.length) {
 					const [url, filename] = queue.shift();
 					try {
+						await sleep(200);
 						await download(url, filename);
 					} catch (e) {
 						console.error(e, url, filename);

--- a/background.js
+++ b/background.js
@@ -89,7 +89,7 @@ chrome.runtime.onMessage.addListener(async (arg, sender, sendResponse) => {
 					await sleep(200);
 					await download({ url, filename });
 				} catch (e) {
-					console.error(e, url, filename);
+					console.error(filename, e);
 					chrome.tabs.sendMessage(sender.tab.id, {
 						type: "coursedump_error",
 						error: e.message,

--- a/background.js
+++ b/background.js
@@ -34,8 +34,18 @@ function download(options) {
 				reject(new Error(delta.state.current));
 			}
 		}
-		const timeId = setTimeout(() => {
-			if (id === undefined) reject(new Error("API timeout"));
+		const timeId = setTimeout(async () => {
+			if (id !== undefined) return;
+			if (options.url) {
+				const query = { url: options.url };
+				const items = await chrome.downloads.search(query);
+				if (items.length) {
+					id = items[0].id;
+					if (id in deltas) checkDelta(deltas[id]);
+					return;
+				}
+			}
+			reject(new Error("API timeout"));
 		}, apiTimeout);
 		try {
 			id = await chrome.downloads.download(options);

--- a/background.js
+++ b/background.js
@@ -32,7 +32,7 @@ function download(url, filename) {
 	});
 }
 
-let maxConnextions = 5;
+let maxConnextions = 10;
 let queue;
 
 chrome.runtime.onMessage.addListener((arg, sender, sendResponse) => {

--- a/background.js
+++ b/background.js
@@ -59,11 +59,15 @@ function download(options) {
 }
 
 let maxConnections = 10;
-let queue;
+let queue = [];
 
 chrome.runtime.onMessage.addListener(async (arg, sender, sendResponse) => {
-	if (arg.type === "coursedump_download") {
-		queue = arg.collection;
+	if (arg.type == "coursedump_clear") {
+		queue = [];
+	} else if (arg.type === "coursedump_add") {
+		queue.push(...arg.collection);
+	} else if (arg.type === "coursedump_download") {
+		if (arg.collection) queue = arg.collection;
 		const total = queue.length;
 		if (arg.max) maxConnections = arg.max;
 		let done = 0;

--- a/background.js
+++ b/background.js
@@ -9,12 +9,10 @@ function sleep(ms) {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function download(url, filename) {
+function download(options) {
 	return new Promise(async (resolve, reject) => {
 		try {
-			const id = await chrome.downloads.download({
-				url, filename
-			});
+			const id = await chrome.downloads.download(options);
 			chrome.downloads.onChanged.addListener(function onDownloadComplete(delta) {
 				if (delta.id == id) {
 					if (delta.state && delta.state.current === 'complete') {
@@ -50,7 +48,7 @@ chrome.runtime.onMessage.addListener(async (arg, sender, sendResponse) => {
 				try {
 					[url, filename] = queue.shift();
 					await sleep(200);
-					await download(url, filename);
+					await download({ url, filename });
 				} catch (e) {
 					console.error(e, url, filename);
 					chrome.tabs.sendMessage(sender.tab.id, {

--- a/background.js
+++ b/background.js
@@ -42,7 +42,7 @@ chrome.runtime.onMessage.addListener(async (arg, sender, sendResponse) => {
 		const total = queue.length;
 		if (arg.max) maxConnections = arg.max;
 		let done = 0;
-		const results = await Promise.allSettled(Array(maxConnections).fill(0).map(async () => {
+		const results = await Promise.allSettled(Array(maxConnections).fill().map(async () => {
 			while (queue.length) {
 				let url, filename;
 				try {

--- a/background.js
+++ b/background.js
@@ -32,7 +32,7 @@ function download(url, filename) {
 	});
 }
 
-let maxConnextions = 10;
+let maxConnections = 10;
 let queue;
 
 chrome.runtime.onMessage.addListener((arg, sender, sendResponse) => {
@@ -40,10 +40,10 @@ chrome.runtime.onMessage.addListener((arg, sender, sendResponse) => {
 		queue = arg.collection;
 		(async function () {
 			const total = queue.length;
-			if (arg.max) maxConnextions = arg.max;
+			if (arg.max) maxConnections = arg.max;
 			let done = 0;
 			await new Promise((resolve, _) => {
-				for (let i = 0; i < maxConnextions; i++) {
+				for (let i = 0; i < maxConnections; i++) {
 					start();
 				}
 				async function start() {

--- a/background.js
+++ b/background.js
@@ -64,7 +64,7 @@ function stopAll() {
 	stopFlag = true;
 }
 
-let maxConnections = 10;
+let maxConnections = 15;
 let queue = [];
 
 chrome.runtime.onMessage.addListener(async (arg, sender, sendResponse) => {

--- a/background.js
+++ b/background.js
@@ -46,8 +46,7 @@ chrome.runtime.onMessage.addListener((arg, sender, sendResponse) => {
 			const total = queue.length;
 			if (arg.max) maxConnections = arg.max;
 			let done = 0;
-			await Promise.all(Array(maxConnections).fill(undefined).map(start));
-			async function start() {
+			await Promise.all(Array(maxConnections).fill(0).map(async () => {
 				while (queue.length) {
 					const [url, filename] = queue.shift();
 					try {
@@ -70,7 +69,7 @@ chrome.runtime.onMessage.addListener((arg, sender, sendResponse) => {
 						total: total
 					});
 				}
-			}
+			}));
 			chrome.tabs.sendMessage(sender.tab.id, {
 				type: "coursedump_progress_upd",
 				progress: "done"

--- a/background.js
+++ b/background.js
@@ -50,10 +50,12 @@ chrome.runtime.onMessage.addListener((arg, sender, sendResponse) => {
 					try {
 						await download(url, filename);
 					} catch (e) {
-						console.error(e);
+						console.error(e, url, filename);
 						chrome.tabs.sendMessage(sender.tab.id, {
 							type: "coursedump_error",
-							error: e.message
+							error: e.message,
+							url: url,
+							filename: filename
 						});
 					}
 					done++;

--- a/background.js
+++ b/background.js
@@ -80,7 +80,8 @@ chrome.runtime.onMessage.addListener(async (arg, sender, sendResponse) => {
 		const total = queue.length;
 		if (arg.max) maxConnections = arg.max;
 		let done = 0;
-		const results = await Promise.allSettled(Array(maxConnections).fill().map(async () => {
+		let pids = Array(maxConnections).fill().map((_, i) => i + 1);
+		const results = await Promise.allSettled(pids.map(async pid => {
 			while (!stopFlag && queue.length) {
 				let url, filename;
 				try {
@@ -103,9 +104,10 @@ chrome.runtime.onMessage.addListener(async (arg, sender, sendResponse) => {
 				});
 			}
 		}));
-		for (const result of results) {
-			if (result.status === "rejected") {
-				console.error(result.reason);
+		for (let i = 0; i < results.length; i++) {
+			const r = results[i];
+			if (r.status === "rejected") {
+				console.error(`pid ${i + 1}: ${r.reason}`);
 			}
 		}
 		chrome.tabs.sendMessage(sender.tab.id, {

--- a/background.js
+++ b/background.js
@@ -13,8 +13,7 @@ function download(url, filename) {
 	return new Promise(async (resolve, reject) => {
 		try {
 			const downloadId = await chrome.downloads.download({
-				url: url,
-				filename: filename
+				url, filename
 			});
 			chrome.downloads.onChanged.addListener(function onDownloadComplete(delta) {
 				if (delta.id == downloadId) {
@@ -56,16 +55,14 @@ chrome.runtime.onMessage.addListener(async (arg, sender, sendResponse) => {
 					chrome.tabs.sendMessage(sender.tab.id, {
 						type: "coursedump_error",
 						error: e.message,
-						url: url,
-						filename: filename
+						url, filename
 					});
 				}
 				done++;
 				chrome.tabs.sendMessage(sender.tab.id, {
 					type: "coursedump_progress_upd",
 					progress: "" + Math.floor(10000 * done / total) / 100 + "%",
-					done: done,
-					total: total
+					done, total
 				});
 			}
 		}));

--- a/background.js
+++ b/background.js
@@ -14,13 +14,15 @@ function download(url, filename) {
 			});
 			chrome.downloads.onChanged.addListener(function onDownloadComplete(delta) {
 				if (delta.id == downloadId) {
-					chrome.downloads.onChanged.removeListener(onDownloadComplete);
 					if (delta.state && delta.state.current === 'complete') {
+						chrome.downloads.onChanged.removeListener(onDownloadComplete);
 						resolve();
 					} else if (delta.error) {
+						chrome.downloads.onChanged.removeListener(onDownloadComplete);
 						reject(new Error(delta.error.current));
-					} else {
-						reject(new Error(delta.state ? delta.state.current : "unknown"));
+					} else if (delta.state && delta.state.current === 'interrupted') {
+						chrome.downloads.onChanged.removeListener(onDownloadComplete);
+						reject(new Error(delta.state.current));
 					}
 				}
 			});

--- a/background.js
+++ b/background.js
@@ -30,14 +30,20 @@ function download(url, filename) {
 	});
 }
 
+let maxConnextions = 5;
+let queue;
+
 chrome.runtime.onMessage.addListener((arg, sender, sendResponse) => {
 	if (arg.type === "coursedump_download") {
-		const queue = arg.collection;
+		queue = arg.collection;
 		(async function () {
 			const total = queue.length;
-			const max = 5;
+			if (arg.max) maxConnextions = arg.max;
 			let done = 0;
 			await new Promise((resolve, _) => {
+				for (let i = 0; i < maxConnextions; i++) {
+					start();
+				}
 				async function start() {
 					if (!queue.length) return;
 					const [url, filename] = queue.shift();
@@ -62,9 +68,6 @@ chrome.runtime.onMessage.addListener((arg, sender, sendResponse) => {
 					} else if (queue.length) {
 						start();
 					}
-				}
-				for (let i = 0; i < max; i++) {
-					start();
 				}
 			});
 			chrome.tabs.sendMessage(sender.tab.id, {


### PR DESCRIPTION
When a large number of files are downloaded in a batch download, the download cannot keep up and a large number of files accumulate in the queue, causing an abnormal load. In my environment, the mouse pointer did not even move properly. The script stopped working when the number exceeded 12,000.

Therefore, the number of simultaneous downloads is limited to ~~5~~ ~~10~~ 15. This can be adjusted by changing the value of the variable `maxConnections`.

Since the download status is monitored, the timing of the `done` notification is also at the same time as all the downloads are completed.
